### PR TITLE
Update base URL

### DIFF
--- a/ovos_translate_plugin_nllb/__init__.py
+++ b/ovos_translate_plugin_nllb/__init__.py
@@ -14,7 +14,7 @@ from ovos_utils.xdg_utils import xdg_data_home
 
 
 class NLLB200Translator(LanguageTranslator):
-    __base_url = "https://pretrained-nmt-models.s3.us-west-2.amazonaws.com/CTranslate2/nllb"
+    __base_url = "https://pretrained-nmt-models.s3.us-west-004.backblazeb2.com/CTranslate2/nllb"
 
     MODEL_URLS = {
         "nllb-200_600M_int8": f"{__base_url}/nllb-200_600M_int8_ct2.zip",


### PR DESCRIPTION
The [old URL](https://pretrained-nmt-models.s3.us-west-2.amazonaws.com/CTranslate2/nllb) is giving me `403 Client Error: Forbidden for url: https://pretrained-nmt-models.s3.us-west-2.amazonaws.com/CTranslate2/nllb/flores200_sacrebleu_tokenizer_spm.model`. I updated it to the URL according to [this website](https://forum.opennmt.net/t/nllb-200-with-ctranslate2/5090) to `https://pretrained-nmt-models.s3.us-west-004.backblazeb2.com/CTranslate2/nllb`